### PR TITLE
Derive PartialEq for Color

### DIFF
--- a/src/rustbox.rs
+++ b/src/rustbox.rs
@@ -19,7 +19,7 @@ pub enum Event {
     NoEvent
 }
 
-#[deriving(Copy)]
+#[deriving(Copy, PartialEq)]
 #[repr(C,u16)]
 pub enum Color {
     Default =  0x00,


### PR DESCRIPTION
Allows direct comparison of `Color` values, useful for tests like `cell.fg == cell.bg` or `oldcolor != newcolor`.
