### PR TITLE
Highlight TOML blocks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ The best way to use Rustbox is in your Cargo config file. You are using [Cargo](
 
 In your `Cargo.toml` add the following:
 
-```
+```toml
 [dependencies]
 rustbox = "0.2.1"
 ```
 
 You can also use the current git version by instead adding:
 
-```
+```toml
 [dependencies.rustbox]
 git = "https://github.com/gchp/rustbox.git"
 ```


### PR DESCRIPTION
GitHub added highlighting for TOML syntax recently. See: https://github.com/craigbarnes/rustbox/blob/toml-highlight/README.md#usage