### PR TITLE
Use a structure for initialization options

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,18 +1,20 @@
 #![feature(io)]
+#![feature(core)]
 
 extern crate rustbox;
 
 use std::char;
 use std::old_io::stdio;
 use std::error::Error;
+use std::default::Default;
 
-use rustbox::{Color, RustBox, InitOption};
+use rustbox::{Color, RustBox, InitOptions};
 
 fn main() {
-    let options = [
-        if stdio::stderr_raw().isatty() { Some(InitOption::BufferStderr) } else { None },
-    ];
-    let rustbox = match RustBox::init(&options) {
+    let rustbox = match RustBox::init(InitOptions {
+        buffer_stderr: stdio::stderr_raw().isatty(),
+        ..Default::default()
+    }) {
         Result::Ok(v) => v,
         Result::Err(e) => panic!("{}", e),
     };


### PR DESCRIPTION
This commit also changes the error type returned from `RustBox::init` to match the new options structure and replaces the boxed `Error` with an `IoError` (because this is the only error that can occur).

Using structures for initialization options is more idiomatic (this is what rustc tends to do). Unfortunately, I had to make several unrelated changes in this commit to get a reasonable error type. I can split this into multiple commits but I'd rather not go though the hassle.