### PR TITLE
Fix build on nightly

### DIFF
--- a/src/rustbox.rs
+++ b/src/rustbox.rs
@@ -1,5 +1,4 @@
 #![feature(libc)]
-#![feature(std_misc)]
 #![feature(optin_builtin_traits)]
 
 extern crate gag;
@@ -14,7 +13,6 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::char;
-use std::time::duration::Duration;
 use std::default::Default;
 
 use num::FromPrimitive;
@@ -335,10 +333,10 @@ impl RustBox {
         unpack_event(rc, &ev, raw)
     }
 
-    pub fn peek_event(&self, timeout: Duration, raw: bool) -> EventResult {
+    pub fn peek_event(&self, timeout_ms: i32, raw: bool) -> EventResult {
         let ev = NIL_RAW_EVENT;
         let rc = unsafe {
-            termbox::tb_peek_event(&ev as *const RawEvent, timeout.num_milliseconds() as c_int)
+            termbox::tb_peek_event(&ev as *const RawEvent, timeout_ms as c_int)
         };
         unpack_event(rc, &ev, raw)
     }


### PR DESCRIPTION
`Duration` doesn't provide `num_milliseconds` any more. We could convert the timeout to milliseconds ourselves, but then we would have to handle the possible overflow conditions, so I think it's easier to just take the timeout argument as an `i32` of milliseconds directly. (Although I'd be happy to fix this while keeping `Duration` if you disagree).