### PR TITLE
Const correctness and Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: rust
+rust:
+  - 1.1.0
+  - nightly

--- a/src/rustbox.rs
+++ b/src/rustbox.rs
@@ -377,17 +377,17 @@ impl RustBox {
     }
 
     pub fn poll_event(&self, raw: bool) -> EventResult {
-        let ev = NIL_RAW_EVENT;
+        let mut ev = NIL_RAW_EVENT;
         let rc = unsafe {
-            termbox::tb_poll_event(&ev as *const RawEvent)
+            termbox::tb_poll_event(&mut ev)
         };
         unpack_event(rc, &ev, raw)
     }
 
     pub fn peek_event(&self, timeout: Duration, raw: bool) -> EventResult {
-        let ev = NIL_RAW_EVENT;
+        let mut ev = NIL_RAW_EVENT;
         let rc = unsafe {
-            termbox::tb_peek_event(&ev as *const RawEvent, timeout.num_milliseconds() as c_int)
+            termbox::tb_peek_event(&mut ev, timeout.num_milliseconds() as c_int)
         };
         unpack_event(rc, &ev, raw)
     }


### PR DESCRIPTION
This branch makes `rustbox` compatible with my corresponding pull request to `termbox-sys`, by passing a mutable reference (which automatically coerces into a mutable raw pointer) to `tb_poll_event` and `tb_peek_event`.

It also adds a `.travis.yml` file to (compile-) test rustbox with rust 1.1.0 and nightly.
