### PR TITLE
mark `RustBox` `Send`, but still not `Sync`

### DIFF
--- a/src/rustbox.rs
+++ b/src/rustbox.rs
@@ -5,6 +5,7 @@ extern crate termbox_sys as termbox;
 
 pub use self::style::{Style, RB_BOLD, RB_UNDERLINE, RB_REVERSE, RB_NORMAL};
 
+use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -221,7 +222,7 @@ pub struct RustBox {
     // top-down order. Otherwise it will not properly protect the above fields.
     _running: running::RunningGuard,
     // Termbox is not thread safe. See #39.
-    _phantom: PhantomData<*mut ()>,
+    _phantom: PhantomData<UnsafeCell<()>>,
 }
 
 #[derive(Clone, Copy,Debug)]


### PR DESCRIPTION
I propose another solution for #41 along #44.

The RustBox type is not thread safe, in the sense that multiple
threads may never alter the mutable state of a shared RustBox
at the same time, so it should not be marked Sync.
However, a RustBox type _can_ safely be sent between threads so
it _should_ be marked Send.

This patch makes it possible to wrap a RustBox struct inside
a Mutex type, so that it can still be used when the programmer
decides to do the synchronization theirself.
