### PR TITLE
#[repr(C,u16)] -> #[repr(u16)]

### DIFF
--- a/src/rustbox.rs
+++ b/src/rustbox.rs
@@ -51,7 +51,7 @@ pub enum InputMode {
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C,u16)]
+#[repr(u16)]
 pub enum Color {
     Default =  0x00,
     Black =    0x01,


### PR DESCRIPTION
Because of how attribute parsing works, `#[repr(C,u16)]` is in fact equivalent to just `#[repr(C)]`.

This commit changes the attribute to `#[repr(u16)]` instead.

See rust-lang/rust#34622