### PR TITLE
Use rust 1.8.0 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 rust:
-  - 1.5.0
+  - 1.8.0
   - nightly


### PR DESCRIPTION
`tempfile`, which is a dependency for `gag`, requires cargo 0.9.0 (released with rust 1.8.0) at least.