### PR TITLE
Remove #![feature(core)] from README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ git = "https://github.com/gchp/rustbox.git"
 Then, in your `src/example.rs`:
 
 ```rust
-#![feature(core)]
-
 extern crate rustbox;
 
 use std::error::Error;


### PR DESCRIPTION
When running with latest stable I get this error:

error[E0554]: #[feature] may not be used on the stable release channel
 --> src/main.rs:1:1
  |
1 | #![feature(core)]
  | ^^^^^^^^^^^^^^^^^

However, it appears that this project works fine on stable. At least I was able to compile and use rustbox successfully without that feature line.

Sorry if I'm missing something obvious -- this is day 2 of my dive into Rust.