### PR TITLE
Update termbox-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ name = "rustbox"
 
 [dependencies]
 bitflags = "0.2.1"
-termbox-sys = "0.2.9"
+termbox-sys = "0.2.12"
 gag = "0.1.6"
 num-traits = "0.1.13"


### PR DESCRIPTION
Thanks for this awesome project!
This PR upgrades the `termbox-sys` version to resolve some build issues related to https://github.com/gchp/termbox-sys/pull/20. I'm stuck on that problem too.

I'd be happy if you could merge this change and release a new version!